### PR TITLE
Create install dirs / Typo Fix

### DIFF
--- a/src/.autoconf/Makefile.in
+++ b/src/.autoconf/Makefile.in
@@ -130,11 +130,11 @@ $(LIBDIR)/rnnlmlib.o: 3rdparty/rnnlm/rnnlmlib.cpp 3rdparty/rnnlm/rnnlmlib.h
 
 #Installation
 install: all
-	install -c $(BINDIR)/phonetisaurus-align $(INSTALL_BIN)/
-	install -c $(BINDIR)/phonetisaurus-arpa2wfst $(INSTALL_BIN)/
-	install -c $(BINDIR)/phonetisaurus-g2prnn $(INSTALL_BIN)/
-	install -c $(BINDIR)/phonetisaurus-g2pfst $(INSTALL_BIN)/
-	install -c $(BINDIR)/rnnlm $(INSTALL_BIN)/
+	install -D -m 755 $(BINDIR)/phonetisaurus-align $(INSTALL_BIN)/phonetisaurus-align
+	install -D -m 755 $(BINDIR)/phonetisaurus-arpa2wfst $(INSTALL_BIN)/phonetisaurus-arpa2wfst
+	install -D -m 755 $(BINDIR)/phonetisaurus-g2prnn $(INSTALL_BIN)/phonetisaurus-g2prnn
+	install -D -m 755 $(BINDIR)/phonetisaurus-g2pfst $(INSTALL_BIN)/phonetisaurus-g2pfst
+	install -D -m 755 $(BINDIR)/rnnlm $(INSTALL_BIN)/rnnlm
 
 #Uninstall
 uninstall:

--- a/src/bin/phonetisaurus-g2pfst.cc
+++ b/src/bin/phonetisaurus-g2pfst.cc
@@ -66,7 +66,7 @@ void EvaluateWordlist (PhonetisaurusScript& decoder, vector<string> corpus,
   }
 }
 
-void ThreadedEvalaateWordlist (string FLAGS_model, vector<string> corpus,
+void ThreadedEvaluateWordlist (string FLAGS_model, vector<string> corpus,
 			       int FLAGS_beam, int FLAGS_nbest, 
 			       bool FLAGS_reverse, string FLAGS_skip,
 			       double FLAGS_thresh, string FLAGS_gsep,


### PR DESCRIPTION
- Create install dirs if they don't exist yet
- Fixed a typo in `ThreadedEvaluateWordlist` function name
