### PR TITLE
Make phonetisaurus-align return 0 on exit

### DIFF
--- a/src/bin/phonetisaurus-align.cc
+++ b/src/bin/phonetisaurus-align.cc
@@ -325,5 +325,5 @@ int main( int argc, char* argv[] ){
     write_alignments (&aligner, FLAGS_ofile, pthresh, FLAGS_nbest,
 		      FLAGS_fb, FLAGS_penalize);
 
-  return 1;
+  return 0;
 }


### PR DESCRIPTION
Returning 1 is an error code, while the program succeeded.
