### PR TITLE
fix Python 3 ur""

### DIFF
--- a/src/scripts/phonetisaurus-apply
+++ b/src/scripts/phonetisaurus-apply
@@ -65,7 +65,7 @@ class G2PModelTester () :
         with open (self.lexicon_file, "r") as ifp :
             for line in ifp :
                 line = line.decode ("utf8").strip ()
-                word, pron = re.split (ur"\t", line)
+                word, pron = re.split (u"\\t", line)
                 _lexicon [word].append (pron)
 
         return _lexicon


### PR DESCRIPTION
According to https://stackoverflow.com/questions/26063899/python-version-3-4-does-not-support-a-ur-prefix?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa the `ur"..."` prefix for strings is not implemented.
