### PR TITLE
make sure pronunciation is complete

### DIFF
--- a/src/scripts/phonetisaurus-apply
+++ b/src/scripts/phonetisaurus-apply
@@ -65,7 +65,7 @@ class G2PModelTester () :
         with open (self.lexicon_file, "r") as ifp :
             for line in ifp :
                 line = line.decode ("utf8").strip ()
-                word, pron = re.split (ur"\t", line)
+                word, pron = re.split (ur"\t", line, 1)
                 _lexicon [word].append (pron)
 
         return _lexicon


### PR DESCRIPTION
In some cases, we use lexicon with tabs in the pronunciation, the tabs meaning syllable boundary. This fix allows for properly handling these cases and does not affect any other case.