### PR TITLE
Define exp10 to build on *BSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,7 +68,7 @@ AC_CHECK_TYPES([ptrdiff_t])
 # Checks for library functions.
 AC_FUNC_STRTOD
 AC_CHECK_FUNCS([memmove strchr strrchr strspn])
-
+AC_CHECK_MATH_FUNC(exp10)
 
 AC_ARG_WITH([openfst-includes],
 	[AS_HELP_STRING([--with-openfst-includes],

--- a/src/3rdparty/rnnlm/rnnlmlib.h
+++ b/src/3rdparty/rnnlm/rnnlmlib.h
@@ -12,7 +12,7 @@
 #define _RNNLMLIB_H_
 
 #define MAX_STRING 100
-#ifdef __APPLE__
+#ifndef HAVE_EXP10
 #define exp10(n) pow((double)10,(4-n))
 #endif 
 


### PR DESCRIPTION
The rnnlmlib only defined exp10 on Apple systems, instead of all systems missing the exp10 function.