### PR TITLE
README: simplify cmudict cleanup code

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,7 @@ $ wget https://raw.githubusercontent.com/cmusphinx/cmudict/master/cmudict.dict
 # Clean it up a bit and reformat:
 $ cat cmudict.dict \
   | perl -pe 's/\([0-9]+\)//;
-              s/\s+/ /g; s/^\s+//;
-              s/\s+$//; @_ = split (/\s+/);
+              @_ = split;
               $w = shift (@_);
               $_ = $w."\t".join (" ", @_)."\n";' \
   > cmudict.formatted.dict


### PR DESCRIPTION
Perl [split](https://perldoc.perl.org/functions/split) without arguments takes care of whitespace cleanup.