### PR TITLE
Add parentheses to print statement for Python 3 compatibility

### DIFF
--- a/python/script/phoneticize.py
+++ b/python/script/phoneticize.py
@@ -84,5 +84,5 @@ if __name__ == "__main__" :
                 word = word.decode ("utf8").strip ()
                 args.token = word
                 Phoneticize (model, args)
-                print "-----------------------"
-                print ""
+                print ("-----------------------")
+                print ("")


### PR DESCRIPTION
Updated print statements to use parentheses to ensure compatibility with Python 3.